### PR TITLE
fix: 修复 queue 类型消息在 send 方法中因缺少 text 属性导致报错

### DIFF
--- a/res/class/EchoMoJi.js
+++ b/res/class/EchoMoJi.js
@@ -307,6 +307,10 @@ class EchoMoJi {
                 )
             );
         }
+        if (typeof message === 'object' && message.type === 'queue') {
+            this.setMessageQueue(message.content);
+            return this.send(this.getMessageQueueFirst());
+        }
         if (typeof message !== 'object') return;
         if (!Array.isArray(message)) message = [message];
 


### PR DESCRIPTION
问题描述：
当 messages 数组中只有一条 queue 类型消息时，next() 方法会直接将其传入 send()。
send() 方法将其作为普通对象处理，尝试访问 e.text 属性，但 queue 对象只有
type 和 content 属性，导致 e.text 为 undefined，最终在 fillTextVariables()
中调用 text.search() 时报错。

修复方案：
在 send() 方法中增加对 queue 类型的判断，遇到 queue 类型时自动展开其
content 数组并加入消息队列，然后发送队列第一个元素。

影响范围：
- 修复了 queue 类型消息在特定场景下的崩溃问题
- 不影响其他消息类型的正常处理